### PR TITLE
Hide broken EDIT button for dataset name

### DIFF
--- a/src/components/Dataset.tsx
+++ b/src/components/Dataset.tsx
@@ -314,7 +314,9 @@ export const Dataset = (): JSX.Element => {
 									<Box className="infoCard">
 										<Typography className="title">About</Typography>
 										{
-											editingName ? <>:
+											// FIXME: "Update Dataset" endpoint is missing body parameter
+
+											/*editingName ? <>:
 													<ClowderInput required={true} onChange={(event) => {
 														const { value } = event.target;
 														setNewDatasetName(value);
@@ -330,7 +332,7 @@ export const Dataset = (): JSX.Element => {
 												</> :
 												<Typography className="content">Name: {about["name"]}
 													<Button onClick={() => setEditingName(true)} size={"small"}>Edit</Button>
-												</Typography>
+												</Typography>*/
 										}
 										<Typography className="content">Dataset ID: {about["id"]}</Typography>
 										<Typography className="content">Owner: {about["authorId"]}</Typography>


### PR DESCRIPTION
## Problem
I've accidentally merged part of an unfinished feature (sorry again!! :X)

## Approach
This PR will hide the feature in the UI until it can be revisited, and the API endpoint is functioning as expected.

## How to Test
1. Checkout and run this branch locally
2. Login to the Clowder React UI (signup if necessary)
3. Navigate to a Dataset (create one, if necessary)
    * You should see details listed about the metadata on the right side
    * You should NOT see an EDIT button beside the dataset's name