### PR TITLE
[WIP] Add openapi github action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,6 +25,7 @@ jobs:
   # NODE BUILD
   # ----------------------------------------------------------------------
   build:
+    timeout-minutes: 10
     runs-on: ubuntu-latest
 
     strategy:
@@ -47,10 +48,36 @@ jobs:
       - name: install dependencies
         run: npm install
 
-      # compile UI
-      - name: build
-        run: npm run build
+      - name: Login to NCSA Hub
+        uses: docker/login-action@v1
+        with:
+          registry: hub.ncsa.illinois.edu
+          username: ${{ secrets.HUB_USERNAME }}
+          password: ${{ secrets.HUB_PASSWORD }}
 
+      - name: Start container
+        run: docker run --rm -itd --name=clowder-fastapi -p 80:80 hub.ncsa.illinois.edu/clowder/clowder-fastapi:main
+
+      - name: Wait for FastAPI
+        run: while ! curl --output /dev/null --silent --fail http://localhost:80; do sleep 1 && echo -n .; done;
+  
+      - name: Save temp OpenAPI spec
+        run: docker exec clowder-fastapi curl localhost/api/v2/openapi.json > ./openapi.json
+
+      - name: Generate client from saved spec
+        run: npm run codegen:v2
+        # Trick codegen into using a local file
+        env:
+          CLOWDER_REMOTE_HOST: ' '
+          CLOWDER_PATH_PREFIX: '.'
+
+      - name: Stop container
+        if: always()
+        run: docker rm -f clowder-fastapi
+
+      - name: Run webpack build
+        run: npm build
+  
   # ----------------------------------------------------------------------
   # DOCKER BUILD
   # ----------------------------------------------------------------------

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,6 +54,9 @@ jobs:
           registry: hub.ncsa.illinois.edu
           username: ${{ secrets.HUB_USERNAME }}
           password: ${{ secrets.HUB_PASSWORD }}
+          
+      #- name: Compute initial hash
+      #  run: echo "OPENAPI_HASH_INIT=$(tar -c . | sha1sum)" >> $GITHUB_ENV
 
       - name: Start container
         run: docker run --rm -itd --name=clowder-fastapi -p 80:80 hub.ncsa.illinois.edu/clowder/clowder-fastapi:main
@@ -74,6 +77,16 @@ jobs:
       - name: Stop container
         if: always()
         run: docker rm -f clowder-fastapi
+        
+      #- name: Compute new hash
+      #  run: echo "OPENAPI_HASH_FINAL=$(tar -c . | sha1sum)" >> $GITHUB_ENV
+        
+      - name: Commit and push if changes detected
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: "[AUTO] Regenerate OpenAPI client"
+          file_pattern: src/openapi/v2/*
+          skip_dirty_check: false
 
       - name: Run webpack build
         run: npm build

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"lint": "eslint src",
 		"lint:fix": "npm run lint -- --fix",
 		"codegen:v1": "./node_modules/.bin/openapi -i https://clowder.ncsa.illinois.edu/clowder/swagger -o src/openapi/v1",
-		"codegen:v2": "./node_modules/.bin/openapi -i ${CLOWDER_REMOTE_HOST}/api/v2/openapi.json -o src/openapi/v2",
+		"codegen:v2": "./node_modules/.bin/openapi -i ${CLOWDER_REMOTE_HOST:-http://clowder.docker.localhost}${CLOWDER_PATH_PREFIX:-/api/v2}/openapi.json -o src/openapi/v2",
 		"codegen": "npm run codegen:v1 && npm run codegen:v2",
 		"docs": "typedoc"
 	},


### PR DESCRIPTION
This is not yet ready for review, but I needed to create a PR to test the GitHub Action :pray:

## Problem
It will become increasingly difficult to keep this generated client in-sync.

## Approach
Add a new github action to regenerate the client code from the existing spec whenever a new PR is submitted. This ensures that client code reflects what endpoints are available from the server.

NOTE: this will currently pull the [`clowder/clowder-fastapi:main`](https://github.com/clowder-framework/clowder2-react-frontend/pull/46/files#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddR61-R68) Docker image and use that to produce a spec. The assumption is that any changes to the API would be merged to main before we begin working on implementing them in the UI, but this may not always hold true.

This may be fragile, and requires further testing. I will also admit that I am a bit nervous about automating anything that would commit to a feature branch. 