### PR TITLE
When authorization token expires need to logout user and then redirect to /login page #43

### DIFF
--- a/src/actions/common.js
+++ b/src/actions/common.js
@@ -1,3 +1,5 @@
+import {LOGOUT, logoutHelper} from "./user";
+
 export const RESET_FAILED = "RESET_FAILED";
 export function resetFailedReason(){
 	return (dispatch) => {
@@ -17,4 +19,27 @@ export function resetLogout(){
 			receivedAt: Date.now(),
 		});
 	};
+}
+
+export const FAILED = "FAILED";
+export function handleErrors(reason){
+	// Authorization error we need to automatically logout user
+	if (reason.status === 401){
+		logoutHelper();
+		return (dispatch) => {
+			dispatch({
+				type: LOGOUT,
+				receivedAt: Date.now()
+			});
+		};
+	}
+	else{
+		return (dispatch) => {
+			dispatch({
+				type: FAILED,
+				reason: reason,
+				receivedAt: Date.now()
+			});
+		};
+	}
 }

--- a/src/actions/common.js
+++ b/src/actions/common.js
@@ -8,3 +8,13 @@ export function resetFailedReason(){
 		});
 	};
 }
+
+export const RESET_LOGOUT = "RESET_LOGOUT";
+export function resetLogout(){
+	return (dispatch) => {
+		dispatch({
+			type:RESET_LOGOUT,
+			receivedAt: Date.now(),
+		});
+	};
+}

--- a/src/actions/common.js
+++ b/src/actions/common.js
@@ -37,7 +37,7 @@ export function handleErrors(reason){
 		return (dispatch) => {
 			dispatch({
 				type: FAILED,
-				reason: reason,
+				reason: reason.message !== undefined? reason.message : "Backend Failure. Couldn't fetch!",
 				receivedAt: Date.now()
 			});
 		};

--- a/src/actions/dataset.js
+++ b/src/actions/dataset.js
@@ -1,159 +1,90 @@
 import {V2} from "../openapi";
 import {LOGOUT, logoutHelper} from "./user";
-
-export const FAILED = "FAILED";
+import {handleErrors} from "./common";
 
 export const RECEIVE_FILES_IN_DATASET = "RECEIVE_FILES_IN_DATASET";
-function receiveFilesInDataset(type, json, reason="") {
-	return (dispatch) => {
-		dispatch({
-			type: type,
-			files: json,
-			reason: reason,
-			receivedAt: Date.now(),
-		});
-	};
-}
 export function fetchFilesInDataset(id){
 	return (dispatch) => {
 		return V2.DatasetsService.getDatasetFilesApiV2DatasetsDatasetIdFilesGet(id)
 			.then(json => {
-				dispatch(receiveFilesInDataset(RECEIVE_FILES_IN_DATASET, json));
+				dispatch({
+					type: RECEIVE_FILES_IN_DATASET,
+					files: json,
+					receivedAt: Date.now(),
+				});
 			})
 			.catch(reason => {
-				if (reason.status === 401){
-					logoutHelper();
-					dispatch(receiveFilesInDataset(LOGOUT, []));
-				}
-				else{
-					dispatch(receiveFilesInDataset(FAILED, [], `Cannot list files in dataset! ${reason}`));
-				}
-			})	;
+				dispatch(handleErrors(reason));
+			});
 	};
 }
 
 export const RECEIVE_DATASET_ABOUT = "RECEIVE_DATASET_ABOUT";
-function receiveDatasetAbout(type, json, reason="") {
-	return (dispatch) => {
-		dispatch({
-			type: type,
-			about: json,
-			reason: reason,
-			receivedAt: Date.now(),
-		});
-	};
-}
 export function fetchDatasetAbout(id){
 	return (dispatch) => {
 		return V2.DatasetsService.getDatasetApiV2DatasetsDatasetIdGet(id)
 			.then(json => {
-				dispatch(receiveDatasetAbout(RECEIVE_DATASET_ABOUT, json));
+				dispatch({
+					type: RECEIVE_DATASET_ABOUT,
+					about: json,
+					receivedAt: Date.now(),
+				});
 			})
 			.catch(reason => {
-				if (reason.status === 401) {
-					logoutHelper();
-					dispatch(receiveDatasetAbout(LOGOUT, []));
-				}
-				else{
-					dispatch(receiveDatasetAbout(FAILED, [], `Cannot fetch Dataset! ${reason}`));
-				}
+				dispatch(handleErrors(reason));
 			});
 	};
 }
 
 export const RECEIVE_DATASETS = "RECEIVE_DATASETS";
-function receiveDatasets(type, json, reason="") {
-	return (dispatch) => {
-		dispatch({
-			type: type,
-			datasets: json,
-			reason: reason,
-			receivedAt: Date.now(),
-		});
-	};
-}
 export function fetchDatasets(when, date, limit=5){
 	return (dispatch) => {
 		// TODO: Parameters for dates? paging?
 		return V2.DatasetsService.getDatasetsApiV2DatasetsGet(0, limit)
 			.then(json => {
-				dispatch(receiveDatasets(RECEIVE_DATASETS, json));
+				dispatch({
+					type: RECEIVE_DATASETS,
+					datasets: json,
+					receivedAt: Date.now(),
+				});
 			})
 			.catch(reason => {
-				// Authorization error we need to automatically logout user
-				if (reason.status === 401){
-					logoutHelper();
-					dispatch({
-						type: LOGOUT,
-						receivedAt: Date.now()
-					});
-				}
-				else{
-					dispatch({
-						type: FAILED,
-						reason: `Cannot fetch dataset! ${reason}`,
-						receivedAt: Date.now()
-					});
-				}
+				dispatch(handleErrors(reason));
 			});
 
 	};
 }
 
 export const CREATE_DATASET = "CREATE_DATASET";
-function createDataset(type, json, reason="") {
-	return (dispatch) => {
-		dispatch({
-			type: type,
-			dataset: json,
-			reason: reason,
-			receivedAt: Date.now(),
-		});
-	};
-}
 export function datasetCreated(formData){
 	return (dispatch) =>{
 		return V2.DatasetsService.saveDatasetApiV2DatasetsPost(formData)
 			.then(dataset => {
-				dispatch(createDataset(CREATE_DATASET, dataset));
+				dispatch({
+					type: CREATE_DATASET,
+					dataset: dataset,
+					receivedAt: Date.now(),
+				});
 			})
 			.catch(reason => {
-				if (reason.status === 401) {
-					logoutHelper();
-					dispatch(createDataset(LOGOUT, {}));
-				}
-				else{
-					dispatch(createDataset(FAILED, {}, `Cannot create dataset! ${reason}`));
-				}
+				dispatch(handleErrors(reason));
 			});
 	};
 }
 
 export const DELETE_DATASET = "DELETE_DATASET";
-function deleteDataset(type, json, reason="") {
-	return (dispatch) => {
-		dispatch({
-			type: type,
-			dataset: json,
-			reason: reason,
-			receivedAt: Date.now(),
-		});
-	};
-}
 export function datasetDeleted(datasetId){
 	return (dispatch) => {
 		return V2.DatasetsService.deleteDatasetApiV2DatasetsDatasetIdDelete(datasetId)
 			.then(json => {
-				dispatch(deleteDataset(DELETE_DATASET, {"id": datasetId}));
+				dispatch({
+					type: DELETE_DATASET,
+					dataset: json,
+					receivedAt: Date.now(),
+				});
 			})
 			.catch(reason => {
-				if (reason.status === 401){
-					logoutHelper();
-					dispatch(deleteDataset(LOGOUT, {}));
-				}
-				else{
-					dispatch(deleteDataset(FAILED, {"id": null}, `Cannot delete dataset! ${reason}`));
-				}
+				dispatch(handleErrors(reason));
 			});
 	};
 }

--- a/src/actions/dataset.js
+++ b/src/actions/dataset.js
@@ -1,4 +1,5 @@
 import {V2} from "../openapi";
+import {logout, LOGOUT} from "./user";
 
 export const FAILED = "FAILED";
 
@@ -23,8 +24,7 @@ export function fetchFilesInDataset(id){
 			})
 			.catch(reason => {
 				if (reason.status === 401){
-					console.log("Unauthorized!");
-				// logout();
+					dispatch(receiveFilesInDataset(LOGOUT, [], "Not authorized!"));
 				}
 				dispatch(receiveFilesInDataset(FAILED, [], `Cannot list files in dataset! ${reason}`));
 			})	;
@@ -52,8 +52,7 @@ export function fetchDatasetAbout(id){
 			})
 			.catch(reason => {
 				if (reason.status === 401) {
-					console.log("Unauthorized!");
-				// logout();
+					dispatch(receiveDatasetAbout(LOGOUT, [], "Not authorized!"));
 				}
 				dispatch(receiveDatasetAbout(FAILED, [], `Cannot fetch Dataset! ${reason}`));
 			});
@@ -81,9 +80,9 @@ export function fetchDatasets(when, date, limit=5){
 				dispatch(receiveDatasets(RECEIVE_DATASETS, json));
 			})
 			.catch(reason => {
-				if (reason.status === 401) {
-					console.log("Unauthorized!");
-				// logout();
+				// Authorization error we need to automatically logout user
+				if (reason.status === 401){
+					dispatch(receiveDatasets(LOGOUT, [], "Not authorized!"));
 				}
 				dispatch(receiveDatasets(FAILED, [], `Cannot fetch dataset! ${reason}`));
 			});
@@ -104,8 +103,12 @@ export function datasetCreated(formData){
 		})
 			.catch(reason => {
 				if (reason.status === 401) {
-					console.error("Failed to create dataset: Not authenticated: ", reason);
-				// logout();
+					dispatch({
+						type: LOGOUT,
+						dataset: {},
+						reason: "Not Authorized!",
+						receivedAt: Date.now(),
+					});
 				}
 				dispatch({
 					type: FAILED,
@@ -131,8 +134,12 @@ export function datasetDeleted(datasetId){
 			})
 			.catch(reason => {
 				if (reason.status === 401){
-					console.log("Unauthorized!");
-				// logout();
+					dispatch({
+						type: LOGOUT,
+						dataset: {},
+						reason: "Not Authorized!",
+						receivedAt: Date.now(),
+					});
 				}
 				dispatch({
 					type: FAILED,

--- a/src/actions/dataset.js
+++ b/src/actions/dataset.js
@@ -83,10 +83,17 @@ export function fetchDatasets(when, date, limit=5){
 				// Authorization error we need to automatically logout user
 				if (reason.status === 401){
 					logoutHelper();
-					dispatch(receiveDatasets(LOGOUT, []));
+					dispatch({
+						type: LOGOUT,
+						receivedAt: Date.now()
+					});
 				}
 				else{
-					dispatch(receiveDatasets(FAILED, [], `Cannot fetch dataset! ${reason}`));
+					dispatch({
+						type: FAILED,
+						reason: `Cannot fetch dataset! ${reason}`,
+						receivedAt: Date.now()
+					});
 				}
 			});
 

--- a/src/actions/file.js
+++ b/src/actions/file.js
@@ -1,20 +1,11 @@
 import config from "../app.config";
 import {dataURItoFile, getHeader} from "../utils/common";
 import {V2} from "../openapi";
+import {handleErrors} from "./common";
 
 export const FAILED = "FAILED";
 
 export const RECEIVE_FILE_EXTRACTED_METADATA = "RECEIVE_FILE_EXTRACTED_METADATA";
-function receiveFileExtractedMetadata(type, json, reason=""){
-	return (dispatch) => {
-		dispatch({
-			type: type,
-			extractedMetadata: json,
-			reason: reason,
-			receivedAt: Date.now(),
-		});
-	};
-}
 export function fetchFileExtractedMetadata(id){
 	const url = `${config.hostname}/files/${id}/extracted_metadata`;
 	return (dispatch) => {
@@ -22,57 +13,41 @@ export function fetchFileExtractedMetadata(id){
 			.then((response) => {
 				if (response.status === 200) {
 					response.json().then(json =>{
-						dispatch(receiveFileExtractedMetadata(RECEIVE_FILE_EXTRACTED_METADATA, json));
+						dispatch({
+							type: RECEIVE_FILE_EXTRACTED_METADATA,
+							extractedMetadata: json,
+							receivedAt: Date.now(),
+						});
 					});
 				}
-				else if (response.status === 401){
-					dispatch(receiveFileExtractedMetadata(FAILED, [], "Cannot fetch extracted file metadata!"));
+				else {
+					dispatch(handleErrors(response));
 				}
 			})
 			.catch(reason => {
-				dispatch(receiveFileExtractedMetadata(FAILED, [], `Cannot fetch extracted file metadata!`));
+				dispatch(handleErrors(reason));
 			});
 	};
 }
 
 export const RECEIVE_FILE_METADATA = "RECEIVE_FILE_METADATA";
-export function receiveFileMetadata(type, json, reason=""){
-	return (dispatch) => {
-		dispatch({
-			type: type,
-			fileMetadata: json,
-			reason: reason,
-			receivedAt: Date.now(),
-		});
-	};
-}
 export function fetchFileMetadata(id){
 	return (dispatch) => {
 		return V2.FilesService.getFileSummaryApiV2FilesFileIdSummaryGet(id)
 			.then(json => {
-				dispatch(receiveFileMetadata(RECEIVE_FILE_METADATA, json));
+				dispatch({
+					type: RECEIVE_FILE_METADATA,
+					fileMetadata: json,
+					receivedAt: Date.now(),
+				});
 			})
 			.catch(reason => {
-				if (reason.status === 401){
-					console.log("Unauthorized!");
-				// logout();
-				}
-				dispatch(receiveFileMetadata(FAILED, [], `Cannot fetch file metadata! ${reason}`));
+				dispatch(handleErrors(reason));
 			});
 	};
 }
 
 export const RECEIVE_FILE_METADATA_JSONLD = "RECEIVE_FILE_METADATA_JSONLD";
-export function receiveFileMetadataJsonld(type, json, reason=""){
-	return (dispatch) => {
-		dispatch({
-			type: type,
-			metadataJsonld: json,
-			receivedAt: Date.now(),
-			reason: reason
-		});
-	};
-}
 export function fetchFileMetadataJsonld(id){
 	const url = `${config.hostname}/files/${id}/metadata.jsonld`;
 	return (dispatch) => {
@@ -80,30 +55,24 @@ export function fetchFileMetadataJsonld(id){
 			.then((response) => {
 				if (response.status === 200) {
 					response.json().then(json =>{
-						dispatch(receiveFileMetadataJsonld(RECEIVE_FILE_METADATA_JSONLD, json));
+						dispatch({
+							type: RECEIVE_FILE_METADATA_JSONLD,
+							metadataJsonld: json,
+							receivedAt: Date.now(),
+						});
 					});
 				}
 				else {
-					dispatch(receiveFileMetadataJsonld(FAILED, [], "Cannot fetch file metadata data jsonld!"));
+					dispatch(handleErrors(response));
 				}
 			})
 			.catch(reason => {
-				dispatch(receiveFileMetadataJsonld(FAILED, [], `Cannot fetch file metadata data jsonld!`));
+				dispatch(handleErrors(reason));
 			});
 	};
 }
 
 export const RECEIVE_PREVIEWS = "RECEIVE_PREVIEWS";
-export function receiveFilePreviews(type, json, reason=""){
-	return (dispatch) => {
-		dispatch({
-			type: type,
-			previews: json,
-			receivedAt: Date.now(),
-			reason: reason
-		});
-	};
-}
 export function fetchFilePreviews(id){
 	const url = `${config.hostname}/files/${id}/getPreviews`;
 	return (dispatch) => {
@@ -111,15 +80,19 @@ export function fetchFilePreviews(id){
 			.then((response) => {
 				if (response.status === 200) {
 					response.json().then(json =>{
-						dispatch(receiveFilePreviews(RECEIVE_PREVIEWS, json));
+						dispatch({
+							type: RECEIVE_PREVIEWS,
+							previews: json,
+							receivedAt: Date.now(),
+						});
 					});
 				}
 				else {
-					dispatch(receiveFileMetadataJsonld(FAILED, [], "Cannot fetch file previews!"));
+					dispatch(handleErrors(response));
 				}
 			})
 			.catch(reason => {
-				dispatch(receiveFileMetadataJsonld(FAILED, [], `Cannot fetch file previews!`));
+				dispatch(handleErrors(reason));
 			});
 	};
 }
@@ -131,22 +104,12 @@ export function fileDeleted(fileId){
 			.then(json => {
 				dispatch({
 					type: DELETE_FILE,
-					file: {"id": fileId},
-					reason: "",
+					file: {"id": json["id"]},
 					receivedAt: Date.now(),
 				});
 			})
 			.catch(reason => {
-				if (reason.status === 401){
-					console.log("Unauthorized!");
-				// logout();
-				}
-				dispatch({
-					type: FAILED,
-					file: {},
-					receivedAt: Date.now(),
-					reason: `Cannot delete file! ${reason}`,
-				});
+				dispatch(handleErrors(reason));
 			});
 	};
 }
@@ -164,16 +127,7 @@ export function fileCreated(formData, selectedDatasetId){
 				});
 			})
 			.catch(reason => {
-				if (reason.status === 401) {
-					console.error("Failed to create file: Not authenticated: ", reason);
-				// logout();
-				}
-				dispatch({
-					type: FAILED,
-					file: {},
-					reason: `Cannot create file! ${reason}`,
-					receivedAt: Date.now(),
-				});
+				dispatch(handleErrors(reason));
 			});
 	};
 }

--- a/src/actions/file.js
+++ b/src/actions/file.js
@@ -5,7 +5,7 @@ import {V2} from "../openapi";
 export const FAILED = "FAILED";
 
 export const RECEIVE_FILE_EXTRACTED_METADATA = "RECEIVE_FILE_EXTRACTED_METADATA";
-export function receiveFileExtractedMetadata(type, json, reason=""){
+function receiveFileExtractedMetadata(type, json, reason=""){
 	return (dispatch) => {
 		dispatch({
 			type: type,
@@ -25,7 +25,7 @@ export function fetchFileExtractedMetadata(id){
 						dispatch(receiveFileExtractedMetadata(RECEIVE_FILE_EXTRACTED_METADATA, json));
 					});
 				}
-				else {
+				else if (response.status === 401){
 					dispatch(receiveFileExtractedMetadata(FAILED, [], "Cannot fetch extracted file metadata!"));
 				}
 			})

--- a/src/actions/user.js
+++ b/src/actions/user.js
@@ -24,6 +24,11 @@ export async function loginHelper(username, password, register = false) {
 	}
 }
 
+export async function logoutHelper(){
+	V2.OpenAPI.TOKEN = undefined;
+	localStorage.removeItem("Authorization");
+}
+
 export const LOGIN_ERROR = "LOGIN_ERROR";
 export const SET_USER = "SET_USER";
 export const REGISTER_USER = "REGISTER_USER";
@@ -71,8 +76,7 @@ export function register(username, password) {
 
 export function logout() {
 	return (dispatch) => {
-		V2.OpenAPI.TOKEN = undefined;
-		localStorage.removeItem("Authorization");
+		logoutHelper();
 		return dispatch({
 			type: LOGOUT,
 		});

--- a/src/actions/user.js
+++ b/src/actions/user.js
@@ -51,7 +51,6 @@ export function login(username, password) {
 		} else {
 			return dispatch({
 				type: LOGIN_ERROR,
-				Authorization: "",
 				errorMsg: json["errorMsg"] !== undefined && json["errorMsg"] !== "" ? json["errorMsg"]: "Username/Password incorrect!"
 			});
 		}

--- a/src/components/Dashbard.tsx
+++ b/src/components/Dashbard.tsx
@@ -11,7 +11,7 @@ import {downloadDataset} from "../utils/dataset";
 import {Dataset, Dataset as DatasetType, RootState, Thumbnail} from "../types/data";
 import {useDispatch, useSelector} from "react-redux";
 import {datasetDeleted, fetchDatasets, } from "../actions/dataset";
-import {resetFailedReason} from "../actions/common";
+import {resetFailedReason, resetLogout} from "../actions/common";
 import {downloadThumbnail} from "../utils/thumbnail";
 import TopBar from "./childComponents/TopBar";
 
@@ -40,6 +40,7 @@ export const Dashboard = (): JSX.Element => {
 	const deleteDataset = (datasetId: string) => dispatch(datasetDeleted(datasetId));
 	const listDatasets = (when: string, date: string, limit: number) => dispatch(fetchDatasets(when, date, limit));
 	const dismissError = () => dispatch(resetFailedReason());
+	const dismissLogout = () => dispatch(resetLogout());
 	const datasets = useSelector((state: RootState) => state.dataset.datasets);
 	const reason = useSelector((state: RootState) => state.dataset.reason);
 	const loggedOut = useSelector((state: RootState) => state.dataset.loggedOut);
@@ -82,7 +83,8 @@ export const Dashboard = (): JSX.Element => {
 	// log user out if unauthorized
 	useEffect(() => {
 		if (loggedOut) {
-			logoutHelper();
+			// reset loggedOut flag so it doesn't stuck in "true" state, then redirect to login page
+			dismissLogout();
 			history("/login");
 		}
 	}, [loggedOut]);

--- a/src/components/Dashbard.tsx
+++ b/src/components/Dashbard.tsx
@@ -19,8 +19,8 @@ import {TabPanel} from "./childComponents/TabComponent";
 import {a11yProps} from "./childComponents/TabComponent";
 import {useNavigate} from "react-router-dom";
 import {MainBreadcrumbs} from "./childComponents/BreadCrumb";
-import {useHistory} from "react-router-dom";
 import {ActionModal} from "./childComponents/ActionModal";
+import {logoutHelper} from "../actions/user";
 
 const tab = {
 	fontStyle: "normal",
@@ -42,6 +42,7 @@ export const Dashboard = (): JSX.Element => {
 	const dismissError = () => dispatch(resetFailedReason());
 	const datasets = useSelector((state: RootState) => state.dataset.datasets);
 	const reason = useSelector((state: RootState) => state.dataset.reason);
+	const loggedOut = useSelector((state: RootState) => state.dataset.loggedOut);
 
 	const [datasetThumbnailList, setDatasetThumbnailList] = useState<any>([]);
 	const [limit,] = useState<number>(5);
@@ -77,6 +78,14 @@ export const Dashboard = (): JSX.Element => {
 		dismissError();
 		setErrorOpen(false);
 	}
+
+	// log user out if unauthorized
+	useEffect(() => {
+		if (loggedOut) {
+			logoutHelper();
+			history("/login");
+		}
+	}, [loggedOut]);
 
 	// fetch thumbnails from each individual dataset/id calls
 	useEffect(() => {

--- a/src/components/Dashbard.tsx
+++ b/src/components/Dashbard.tsx
@@ -79,7 +79,7 @@ export const Dashboard = (): JSX.Element => {
 		setErrorOpen(false);
 	}
 
-	// log user out if unauthorized
+	// log user out if token expired/unauthorized
 	useEffect(() => {
 		if (loggedOut) {
 			// reset loggedOut flag so it doesn't stuck in "true" state, then redirect to login page

--- a/src/components/Dashbard.tsx
+++ b/src/components/Dashbard.tsx
@@ -20,7 +20,6 @@ import {a11yProps} from "./childComponents/TabComponent";
 import {useNavigate} from "react-router-dom";
 import {MainBreadcrumbs} from "./childComponents/BreadCrumb";
 import {ActionModal} from "./childComponents/ActionModal";
-import {logoutHelper} from "../actions/user";
 
 const tab = {
 	fontStyle: "normal",
@@ -42,8 +41,8 @@ export const Dashboard = (): JSX.Element => {
 	const dismissError = () => dispatch(resetFailedReason());
 	const dismissLogout = () => dispatch(resetLogout());
 	const datasets = useSelector((state: RootState) => state.dataset.datasets);
-	const reason = useSelector((state: RootState) => state.dataset.reason);
-	const loggedOut = useSelector((state: RootState) => state.dataset.loggedOut);
+	const reason = useSelector((state: RootState) => state.error.reason);
+	const loggedOut = useSelector((state: RootState) => state.error.loggedOut);
 
 	const [datasetThumbnailList, setDatasetThumbnailList] = useState<any>([]);
 	const [limit,] = useState<number>(5);

--- a/src/components/Dataset.tsx
+++ b/src/components/Dataset.tsx
@@ -27,7 +27,7 @@ import {File, FileMetadataList, RootState, Thumbnail} from "../types/data";
 import {useDispatch, useSelector} from "react-redux";
 import {downloadThumbnail} from "../utils/thumbnail";
 import {datasetDeleted, fetchDatasetAbout, fetchFilesInDataset} from "../actions/dataset";
-import {resetFailedReason} from "../actions/common"
+import {resetFailedReason, resetLogout} from "../actions/common"
 import {fileDeleted} from "../actions/file";
 
 import {TabPanel} from "./childComponents/TabComponent";
@@ -68,11 +68,13 @@ export const Dataset = (): JSX.Element => {
 	const listFilesInDataset = (datasetId:string|undefined) => dispatch(fetchFilesInDataset(datasetId));
 	const listDatasetAbout= (datasetId:string|undefined) => dispatch(fetchDatasetAbout(datasetId));
 	const dismissError = () => dispatch(resetFailedReason());
+	const dismissLogout = () => dispatch(resetLogout());
 
 	// mapStateToProps
 	const filesInDataset = useSelector((state:RootState) => state.dataset.files);
 	const about = useSelector((state:RootState) => state.dataset.about);
-	const reason = useSelector((state:RootState) => state.dataset.reason);
+	const reason = useSelector((state:RootState) => state.error.reason);
+	const loggedOut = useSelector((state: RootState) => state.error.loggedOut);
 
 	// state
 	const [selectedTabIndex, setSelectedTabIndex] = useState<number>(0);
@@ -112,6 +114,15 @@ export const Dataset = (): JSX.Element => {
 		dismissError();
 		setErrorOpen(false);
 	}
+
+	// log user out if token expired/unauthorized
+	useEffect(() => {
+		if (loggedOut) {
+			// reset loggedOut flag so it doesn't stuck in "true" state, then redirect to login page
+			dismissLogout();
+			history("/login");
+		}
+	}, [loggedOut]);
 
 	// TODO these code will go away in v2 dont worry about understanding them
 	// TODO get metadata of each files; because we need the thumbnail of each file!!!

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from "react";
+import React, {useEffect, useState} from "react";
 import {useNavigate} from "react-router-dom";
 import {Avatar, Button, Paper, TextField, Typography, Link} from "@mui/material";
 import LockOutlinedIcon from "@mui/icons-material/LockOutlined";
@@ -8,11 +8,8 @@ import {login as loginAction} from "../actions/user";
 import {RootState} from "../types/data";
 
 export const Login = (): JSX.Element => {
-
-	// if already login, redirect to homepage
 	// use history hook to redirect/navigate between routes
 	const history = useNavigate();
-	if (isAuthorized()) { history("/");}
 
 	const dispatch = useDispatch();
 	const login = (username:string, password:string) => dispatch(loginAction(username, password));
@@ -24,11 +21,12 @@ export const Login = (): JSX.Element => {
 	const [passwordErrorText, setPasswordErrorText] = useState("");
 	const [promptError, setPromptError] = useState(false);
 
-	// TODO need to figure out what to do when login succeeded
-	// // login success
-	// useEffect(() => {
-	// 	if (Authorization !== "") history.push("/");
-	// }, [Authorization]);
+	// if already login, redirect to homepage
+	// use history hook to redirect/navigate between routes
+	// component did mount
+	useEffect(() => {
+		if (isAuthorized()) { history("/");}
+		}, []);
 
 	const handleKeyPressed= async (event: React.KeyboardEvent<{}>) => {
 		if (event.key === "Enter") { await handleLoginButtonClick();}

--- a/src/reducers/dataset.ts
+++ b/src/reducers/dataset.ts
@@ -4,10 +4,7 @@ import {
 	RECEIVE_DATASETS,
 	DELETE_DATASET,
 	CREATE_DATASET,
-	FAILED,
 } from "../actions/dataset";
-import {LOGOUT} from "../actions/user";
-import {RESET_FAILED, RESET_LOGOUT} from "../actions/common";
 import {CREATE_FILE, DELETE_FILE} from "../actions/file";
 import {DataAction} from "../types/action";
 import {DatasetState} from "../types/data";
@@ -16,20 +13,10 @@ const defaultState: DatasetState = {
 	files: [],
 	about: {name: "", id: "", authorId: "", description: "", created: "", thumbnail: ""},
 	datasets: [],
-	reason: "",
-	loggedOut: false,
 };
 
 const dataset = (state = defaultState, action: DataAction) => {
 	switch (action.type) {
-	case FAILED:
-		return Object.assign({}, state, {reason: action.reason});
-	case RESET_FAILED:
-		return Object.assign({}, state, {reason: action.reason});
-	case LOGOUT:
-		return Object.assign({}, state, {loggedOut: true});
-	case RESET_LOGOUT:
-		return Object.assign({}, state, {loggedOut: false});
 	case RECEIVE_FILES_IN_DATASET:
 		return Object.assign({}, state, {files: action.files});
 	case DELETE_FILE:

--- a/src/reducers/dataset.ts
+++ b/src/reducers/dataset.ts
@@ -6,6 +6,7 @@ import {
 	CREATE_DATASET,
 	FAILED,
 } from "../actions/dataset";
+import {LOGOUT} from "../actions/user";
 import {RESET_FAILED} from "../actions/common";
 import {CREATE_FILE, DELETE_FILE} from "../actions/file";
 import {DataAction} from "../types/action";
@@ -15,13 +16,16 @@ const defaultState: DatasetState = {
 	files: [],
 	about: {name: "", id: "", authorId: "", description: "", created: "", thumbnail: ""},
 	datasets: [],
-	reason: ""
+	reason: "",
+	loggedOut: false,
 };
 
 const dataset = (state = defaultState, action: DataAction) => {
 	switch (action.type) {
 	case FAILED:
 		return Object.assign({}, state, {reason: action.reason});
+	case LOGOUT:
+		return Object.assign({}, state, {loggedOut: true, reason: action.reason});
 	case RESET_FAILED:
 		return Object.assign({}, state, {reason: action.reason})
 	case RECEIVE_FILES_IN_DATASET:

--- a/src/reducers/dataset.ts
+++ b/src/reducers/dataset.ts
@@ -7,7 +7,7 @@ import {
 	FAILED,
 } from "../actions/dataset";
 import {LOGOUT} from "../actions/user";
-import {RESET_FAILED} from "../actions/common";
+import {RESET_FAILED, RESET_LOGOUT} from "../actions/common";
 import {CREATE_FILE, DELETE_FILE} from "../actions/file";
 import {DataAction} from "../types/action";
 import {DatasetState} from "../types/data";
@@ -24,10 +24,12 @@ const dataset = (state = defaultState, action: DataAction) => {
 	switch (action.type) {
 	case FAILED:
 		return Object.assign({}, state, {reason: action.reason});
-	case LOGOUT:
-		return Object.assign({}, state, {loggedOut: true, reason: action.reason});
 	case RESET_FAILED:
-		return Object.assign({}, state, {reason: action.reason})
+		return Object.assign({}, state, {reason: action.reason});
+	case LOGOUT:
+		return Object.assign({}, state, {loggedOut: true});
+	case RESET_LOGOUT:
+		return Object.assign({}, state, {loggedOut: false});
 	case RECEIVE_FILES_IN_DATASET:
 		return Object.assign({}, state, {files: action.files});
 	case DELETE_FILE:

--- a/src/reducers/error.ts
+++ b/src/reducers/error.ts
@@ -1,0 +1,23 @@
+import {DataAction} from "../types/action";
+
+const defaultState = {
+	reason: "",
+	loggedOut: false,
+};
+
+const dataset = (state = defaultState, action: DataAction) => {
+	switch (action.type) {
+		case "FAILED":
+			return Object.assign({}, state, {reason: action.reason});
+		case "RESET_FAILED":
+			return Object.assign({}, state, {reason: action.reason});
+		case "LOGOUT":
+			return Object.assign({}, state, {loggedOut: true});
+		case "RESET_LOGOUT":
+			return Object.assign({}, state, {loggedOut: false});
+		default:
+			return state;
+	}
+};
+
+export default dataset;

--- a/src/reducers/error.ts
+++ b/src/reducers/error.ts
@@ -5,7 +5,7 @@ const defaultState = {
 	loggedOut: false,
 };
 
-const dataset = (state = defaultState, action: DataAction) => {
+const error = (state = defaultState, action: DataAction) => {
 	switch (action.type) {
 		case "FAILED":
 			return Object.assign({}, state, {reason: action.reason});
@@ -20,4 +20,4 @@ const dataset = (state = defaultState, action: DataAction) => {
 	}
 };
 
-export default dataset;
+export default error;

--- a/src/reducers/file.ts
+++ b/src/reducers/file.ts
@@ -14,15 +14,10 @@ const defaultState: FileState = {
 	extractedMetadata: <ExtractedMetadata>{},
 	metadataJsonld: [],
 	previews: [],
-	reason: ""
 };
 
 const file = (state=defaultState, action: DataAction) => {
 	switch(action.type) {
-	case FAILED:
-		return Object.assign({}, state, {reason:action.reason});
-	case RESET_FAILED:
-		return Object.assign({}, state, {reason: action.reason})
 	case RECEIVE_FILE_METADATA:
 		return Object.assign({}, state, {fileMetadata: action.fileMetadata});
 	case RECEIVE_FILE_EXTRACTED_METADATA:

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -2,11 +2,13 @@ import { combineReducers } from "redux";
 import file from "./file";
 import dataset from "./dataset";
 import user from "./user";
+import error from "./error";
 
 const rootReducer = combineReducers({
 	file: file,
 	dataset: dataset,
 	user: user,
+	error: error
 });
 
 export default rootReducer;

--- a/src/reducers/user.ts
+++ b/src/reducers/user.ts
@@ -21,6 +21,7 @@ const user = (state = defaultState, action: DataAction) => {
 		return Object.assign({}, state, {registerSucceeded: false, errorMsg: action.errorMsg});
 	case LOGOUT:
 		return Object.assign({}, state, {Authorization: null, loginError: false});
+
 	default:
 		return state;
 	}

--- a/src/reducers/user.ts
+++ b/src/reducers/user.ts
@@ -1,4 +1,4 @@
-import {SET_USER, LOGIN_ERROR, LOGOUT, REGISTER_ERROR, REGISTER_USER} from "../actions/user";
+import {SET_USER, LOGIN_ERROR, REGISTER_ERROR, REGISTER_USER} from "../actions/user";
 import {UserState} from "../types/data";
 import {DataAction} from "../types/action";
 
@@ -19,9 +19,6 @@ const user = (state = defaultState, action: DataAction) => {
 		return Object.assign({}, state, {registerSucceeded: true});
 	case REGISTER_ERROR:
 		return Object.assign({}, state, {registerSucceeded: false, errorMsg: action.errorMsg});
-	// case LOGOUT:
-	// 	return Object.assign({}, state, {Authorization: null, loginError: false});
-
 	default:
 		return state;
 	}

--- a/src/reducers/user.ts
+++ b/src/reducers/user.ts
@@ -19,8 +19,8 @@ const user = (state = defaultState, action: DataAction) => {
 		return Object.assign({}, state, {registerSucceeded: true});
 	case REGISTER_ERROR:
 		return Object.assign({}, state, {registerSucceeded: false, errorMsg: action.errorMsg});
-	case LOGOUT:
-		return Object.assign({}, state, {Authorization: null, loginError: false});
+	// case LOGOUT:
+	// 	return Object.assign({}, state, {Authorization: null, loginError: false});
 
 	default:
 		return state;

--- a/src/types/action.ts
+++ b/src/types/action.ts
@@ -57,7 +57,6 @@ interface LOGIN_ERROR{
 interface LOGOUT{
 	type: "LOGOUT",
 	loggedOut: boolean,
-	reason: string,
 }
 
 interface REGISTER_ERROR{
@@ -89,6 +88,11 @@ interface RESET_FAILED{
 	reason: string
 }
 
+interface RESET_LOGOUT{
+	type: "RESET_LOGOUT",
+	loggedOut: boolean
+}
+
 export type DataAction =
 	| RECEIVE_FILES_IN_DATASET
 	| DELETE_FILE
@@ -108,4 +112,5 @@ export type DataAction =
 	| CREATE_FILE
 	| FAILED
 	| RESET_FAILED
+	| RESET_LOGOUT
 	;

--- a/src/types/action.ts
+++ b/src/types/action.ts
@@ -56,6 +56,8 @@ interface LOGIN_ERROR{
 
 interface LOGOUT{
 	type: "LOGOUT",
+	loggedOut: boolean,
+	reason: string,
 }
 
 interface REGISTER_ERROR{

--- a/src/types/action.ts
+++ b/src/types/action.ts
@@ -59,6 +59,11 @@ interface LOGOUT{
 	loggedOut: boolean,
 }
 
+interface RESET_LOGOUT{
+	type: "RESET_LOGOUT",
+	loggedOut: boolean
+}
+
 interface REGISTER_ERROR{
 	errorMsg: string,
 	type: "REGISTER_ERROR"
@@ -86,11 +91,6 @@ interface FAILED{
 interface RESET_FAILED{
 	type: "RESET_FAILED",
 	reason: string
-}
-
-interface RESET_LOGOUT{
-	type: "RESET_LOGOUT",
-	loggedOut: boolean
 }
 
 export type DataAction =

--- a/src/types/data.ts
+++ b/src/types/data.ts
@@ -111,6 +111,7 @@ export interface DatasetState{
 	files: File[];
 	datasets: Dataset[];
 	about: About;
+	loggedOut: boolean;
 }
 
 export interface FileState{

--- a/src/types/data.ts
+++ b/src/types/data.ts
@@ -4,7 +4,6 @@ export interface Dataset {
 	description: string;
 	created: string;
 	thumbnail: string;
-	reason: string;
 }
 
 export interface File {
@@ -13,7 +12,6 @@ export interface File {
 	size: number;
 	"date-created": string;
 	contentType:string;
-	reason:string;
 }
 
 export interface About {
@@ -107,11 +105,9 @@ export interface Thumbnail{
 }
 
 export interface DatasetState{
-	reason: string;
 	files: File[];
 	datasets: Dataset[];
 	about: About;
-	loggedOut: boolean;
 }
 
 export interface FileState{
@@ -129,7 +125,13 @@ export interface UserState{
 	errorMsg: string;
 }
 
+export interface ErrorState{
+	reason: string;
+	loggedOut: boolean;
+}
+
 export interface RootState {
+	error: ErrorState;
 	file:FileState;
 	dataset:DatasetState;
 	user: UserState;

--- a/src/types/data.ts
+++ b/src/types/data.ts
@@ -115,7 +115,6 @@ export interface FileState{
 	extractedMetadata: ExtractedMetadata;
 	metadataJsonld: MetadataJsonld[];
 	previews: FilePreview[];
-	reason: string;
 }
 
 export interface UserState{


### PR DESCRIPTION
This PR mostly address the issue when token is invalid or expired in local storage, frontend will automatically log user out.
To test:
- find "Authorization" in your local storage, and modify the "bearer token" to anything that doesn't make sense
- try different actions on frontend. Whenever you see a 401 error in the console, you should also see it automatically redirect user to the login page

A few other things addressed in the PR:
- make a error reducer and a common function to handle errors to make the code cleaner
- fix a minor bug on Login component. When user already logged in, it will redirect to home page